### PR TITLE
Add "cruw" in the find_packages list 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
         ],
-        packages=find_packages(include=["cruw.*"]),
+        packages=find_packages(include=["cruw", "cruw.*"]),
         # package_dir={'': 'cruw'},
         package_data={'': ['*.json']},
         python_requires='>=3.6',


### PR DESCRIPTION
Hi Yizhou, 

as I tested locally, if without this `"cruw"` item from the `find_packages` list, all the three `.py` files under `cruw` dir could not get included in the build while only the subdirs can be copied. That resulted in the `from cruw import CRUW` statement failing. This fix can resolve my problem locally, and I hope it can help others as well. 

I'm not sure though which branch from the major repo I should target. If `master` is not the correct choice, please just let me know and I will change. 

Thanks a lot for your nice work and preparation for this super interesting challenge :)

K. Li